### PR TITLE
bugfix: Quote templated k8s spec fields

### DIFF
--- a/infra/api_server.yaml
+++ b/infra/api_server.yaml
@@ -50,11 +50,11 @@ spec:
       name: api-server
       labels:
         app: api-server
-        ver: {{ .Values.ver }}
+        ver: "{{ .Values.ver }}"
     spec:
       containers:
         - name: api-server
-          image: {{ .Values.image}}
+          image: "{{ .Values.image}}"
           env:
             - name: PORT
               value: "8080"

--- a/infra/matchmaker.yaml
+++ b/infra/matchmaker.yaml
@@ -31,11 +31,11 @@ spec:
     metadata:
       labels:
         app: matchmaker
-        ver: {{ .Values.ver }}
+        ver: "{{ .Values.ver }}"
     spec:
       containers:
         - name: matchmaker
-          image: {{ .Values.image }}
+          image: "{{ .Values.image }}"
           env:
             - name: PORT
               value: "5050"

--- a/infra/sync_backend.yaml
+++ b/infra/sync_backend.yaml
@@ -29,11 +29,11 @@ spec:
     metadata:
       labels:
         app: sync-backend
-        ver: {{ .Values.ver }}
+        ver: "{{ .Values.ver }}"
     spec:
       containers:
         - name: sync-backend
-          image: {{ .Values.image }}
+          image: "{{ .Values.image }}"
           env:
             - name: PORT
               value: "5050"


### PR DESCRIPTION
When the commit id was identified as a number by yaml we got an error